### PR TITLE
docker-comose.ymlのファイル名を修正したのでMakefileの記載も変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@ SERVICE=django
 
 # コード整形（formatter）
 format:
-	docker compose run --rm $(SERVICE) ruff format .
+	docker compose -f docker-compose.dev.yml run --rm $(SERVICE) ruff format .
 
 # Linter 実行（自動修正あり）
 lint:
-	docker compose run --rm $(SERVICE) ruff check . --fix
+	docker compose -f docker-compose.dev.yml run --rm $(SERVICE) ruff check . --fix
 
 # Linter 実行（自動修正なし）
 lint-check:
-	docker compose run --rm $(SERVICE) ruff check .
+	docker compose -f docker-compose.dev.yml run --rm $(SERVICE) ruff check .


### PR DESCRIPTION
docker-comose.ymlをdocker-comose.dev.ymlに変更したことで
makeコマンドが使用できなくなったので
再度、実行できるようにMakefileも修正