### PR TITLE
アイテム一覧画面に新規登録画面へのリンクを追加

### DIFF
--- a/src/items/templates/items/index.html
+++ b/src/items/templates/items/index.html
@@ -4,9 +4,9 @@
 
 {% block content %}
 <h2>登録アイテム一覧</h2>
-{% comment %}
-    一旦アイテムの表示を追加します。
-{% endcomment %}
+<a href="{% url 'item-create' %}" class="btn btn-primary">
+    追加
+</a>
 {% if items %}
     {% for item in items %}
         <li>{{ item.purchase_date }}</li>


### PR DESCRIPTION
### 対応内容
アイテム一覧画面に新規登録画面へのリンクを追加
（すみません、一旦機能のみです🙇🙇）