### PR TITLE
アイテム編集機能の作成（バックエンド）

### DIFF
--- a/src/items/forms.py
+++ b/src/items/forms.py
@@ -142,3 +142,58 @@ class PhotoUploadForm(forms.Form):
         ),
         required=False,
     )
+
+
+# アイテム編集フォーム
+class ItemUpdateForm(forms.ModelForm):
+    # 画像をアップロードするためのフォーム（Itemモデルにフィールドなくても問題なし）
+    images = forms.FileField(
+        widget=forms.ClearableFileInput(
+            attrs={
+                "multiple": True,  # 複数画像選択可能
+                "accept": "image/*",  # 画像ファイルのみ選択可能
+                "id": "images-input",  # HTMLのiD属性
+            }
+        ),
+        required=False,  # view側にて設定
+    )
+
+    # 編集対象のアイテムのdescriptionが空欄であれば、空文字にする。
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance and self.instance.description is None:
+            self.fields["description"].initial = ""
+
+        # Itemモデルの中に写真フィールドがないため、以下定義が必要
+        self.fields["images"].label = "写真は5枚まで登録できます"
+
+    # itemモデルの中から、指定フィールドを選択しラベルを表示
+    class Meta:
+        model = Item
+        fields = ["purchase_date", "price", "description", "images"]
+        labels = {"purchase_date": "購入日", "price": "価格", "description": "説明"}
+
+        # 入力欄のカスタマイズ
+        #  Updateのため、placeholderは非表示
+        widgets = {
+            "purchase_date": forms.DateInput(
+                attrs={
+                    "class": "form-control",  # CSSにて使用するクラス
+                    # "placeholder": "2025-01-01",
+                }
+            ),
+            "price": forms.NumberInput(
+                attrs={
+                    "class": "form-control",  # CSSにて使用するクラス
+                    # "placeholder": "2000",
+                    "min": "0",  # マイナスの価格入力がブラウザ上で禁止される
+                }
+            ),
+            "description": forms.Textarea(
+                attrs={
+                    "class": "form-control",  # CSSにて使用するクラス
+                    "rows": 4,  # 初期表示で4行文の高さに設定
+                    # "placeholder": "例：二子玉川で購入。かわいい！！",
+                }
+            ),
+        }

--- a/src/items/templates/items/detail.html
+++ b/src/items/templates/items/detail.html
@@ -28,9 +28,7 @@
         {% endfor %}
     </div>
     <div class="detail-btn-container">
-        <a href="{% url 'item-list' %}" class="detail-btn-action btn-edit font-regular">編集する</a>
-        {% comment %} TODO: 編集画面ができたら、L33-34は削除、L35を活性化してください {% endcomment %}
-        {% comment %} <a href="{% url 'item-edit' item.pk %}" class="detail-btn-action btn-edit">編集する</a> {% endcomment %}
+        <a href="{% url 'item-update' item.pk %}" class="detail-btn-action btn-edit">編集する</a>
         <a href="{% url 'item-list' %}" class="detail-btn-action btn-back font-regular">戻る</a>
     </div>
 </div>

--- a/src/items/templates/items/edit.html
+++ b/src/items/templates/items/edit.html
@@ -1,15 +1,62 @@
 {% extends 'base.html' %}
+{% load static %}
 
 {% block title %}アイテム編集{% endblock %}
 
 {% block content %}
-    <h2>アイテム編集</h2>
-    {% comment %}
-        一旦フォームの表示を追加します。
-    {% endcomment %}
-    <form method="post">
+    <h1>アイテム編集</h1>
+
+    {% if messages %}
+        <ul>
+            {% for message in messages %}
+                <li style="color:red">{{ message }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+
+    <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
-        {{ form.as_p }}
-        <button type="submit">更新する</button>
+        
+        {# フォーム全体のエラーの表示 #}
+        {{ form.non_field_errors }}
+
+        {# 各フィールドを個別に表示 #}
+        <div class="form-group">
+        {{ form.purchase_date.label}} {{ form.purchase_date }}
+        </div>
+        <div class="form-group">
+        {{ form.price.label }} {{ form.price }}
+        </div>
+        <div class="form-group">
+        {{ form.description.label }} {{ form.description }}
+        </div>
+
+        <div>
+            {{ photo_form.images.label }} {{ photo_form.images }}
+            {% for e in photo_form.images.errors %}
+                <div style="color:red">{{ e }}</div>
+            {% endfor %}
+        </div>
+
+        {# 画像削除#}
+         {% for photo in photos %}
+        <div class="photo-block">
+            <img src="{{ photo.url }}" alt="登録済み画像" width="150" height="150">
+
+            <label>
+            <input type="checkbox" name="delete_photos" value="{{ photo.id }}">
+            削除
+            </label>
+        </div>
+        {% endfor %} 
+
+        <div id="preview" style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px;"></div>
+
+        <button type="submit">登録する</button>
     </form>
+    <a href="{% url 'item-list' %}" class="btn btn-primary">戻る</a>
+
+    {% block extra_js %}
+        <script src="{% static 'js/preview.js' %}"></script>
+    {% endblock %}    
 {% endblock %}

--- a/src/items/urls.py
+++ b/src/items/urls.py
@@ -7,6 +7,7 @@ from .views import (
     ItemListView,
     ItemDetailView,
     ItemDeleteView,
+    ItemUpdateView,
 )
 from django.contrib.auth.views import LogoutView
 
@@ -19,4 +20,5 @@ urlpatterns = [
     path("items/", ItemListView.as_view(), name="item-list"),
     path("items/<int:pk>", ItemDetailView.as_view(), name="item-detail"),
     path("items/<int:pk>/delete/", ItemDeleteView.as_view(), name="item-delete"),
+    path("items/<int:pk>/update/", ItemUpdateView.as_view(), name="item-update"),
 ]

--- a/src/items/views.py
+++ b/src/items/views.py
@@ -5,7 +5,13 @@ from django.contrib.auth.mixins import LoginRequiredMixin  # 上位に記載必�
 from django.contrib.auth.views import LoginView
 from django.contrib.auth import login, get_user_model
 from django.views import View
-from django.views.generic import CreateView, ListView, DetailView, DeleteView
+from django.views.generic import (
+    CreateView,
+    ListView,
+    DetailView,
+    DeleteView,
+    UpdateView,
+)
 from django.urls import reverse_lazy
 from django.utils.timezone import now
 from django.shortcuts import render, redirect
@@ -22,7 +28,10 @@ from .forms import (
     LoginForm,
     ItemCreateForm,
     PhotoUploadForm,
+    ItemUpdateForm,
 )
+
+# from django.forms.models import model_to_dict
 from django.db.models import OuterRef, Subquery
 
 User = get_user_model()
@@ -129,6 +138,7 @@ class ItemCreateView(LoginRequiredMixin, View):
 
         # (TODO)seasonは暫定で以下のように設定
         item.season = 0
+        item.delete_flag = False
         item.save()
 
         # M2M があればここで
@@ -186,3 +196,90 @@ class ItemDeleteView(LoginRequiredMixin, DeleteView):
 
         # Trueへ変更後、success_urlへリダイレクトする
         return HttpResponseRedirect(self.get_success_url())
+
+
+# アイテム編集
+class ItemUpdateView(LoginRequiredMixin, UpdateView):
+    model = Item
+    template_name = "items/edit.html"
+    form_class = ItemUpdateForm
+    context_object_name = "item"
+
+    # テンプレートへ渡す追加データを定義
+    # Itemモデルへ写真フィールドがなく、かつUI上で画像アップロード欄のみを分離表示しわかりやすくするため。
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["photo_form"] = self.get_form()
+        context["photos"] = (
+            self.object.itemphoto_set.all()
+        )  # ItemPhotoモデルを参照し情報を取得
+        return context
+
+    # ログインしているユーザーに紐づく削除されていないアイテムを抽出
+    def get_queryset(self):
+        user = self.request.user
+
+        return Item.objects.filter(user=user, delete_flag=False)
+
+    # ユーザーがフォームを送信後、バリデーション通過後に行う保存や画面遷移処理のカスタマイズ
+    def form_valid(self, form):
+        # フォームから送られてきたデータをもとにitemオブジェクトを作成
+        # 内容を加工後保存するため、一時保存。
+        item = form.save(commit=False)
+
+        # description欄に記載がなければ、空文字にして表示。（Noneの表示を防ぐ）
+        if item.description is None:
+            item.description = ""
+
+        # 加工後の内容を保存
+        item.save()
+
+        # フォームにてimagesという名前で送信された複数"ファイル"をフォームから受け取る処理
+        images = self.request.FILES.getlist("images")
+
+        # フォーム送信時に複数の削除対象IDを取得するための処理
+        delete_ids = self.request.POST.getlist("delete_photos")
+
+        # 対象アイテムのItemPhotoモデルへ紐づくすべての写真の枚数を数える（削除対象写真は除く)
+        remaining_count = item.itemphoto_set.exclude(id__in=delete_ids).count()
+        # 新しく登録された画像ファイルの要素数
+        new_count = len(images)
+        # 画像の総枚数を計算
+        total_count = remaining_count + new_count
+
+        # 写真は1枚以下だと、バリデーション失敗として編集画面へ戻る(HTMLにてエラーを表示させる設定を行う)
+        if total_count < 1:
+            form.add_error("images", "写真は最低１枚登録してください")
+            return self.form_invalid(form)
+
+        # 写真は５枚以上だと、バリデーション失敗として編集画面へ戻る(HTMLにてエラーを表示させる設定を行う)
+        if total_count > 5:
+            form.add_error("images", "写真は最大５枚まで登録できます")
+            return self.form_invalid(form)
+
+        # 削除対象IDを一括削除
+        if delete_ids:
+            ItemPhoto.objects.filter(id__in=delete_ids, item=item).delete()
+
+        # ユーザーがアップロードした画像をサーバーに保存し、公開URLを取得
+        for img in images:
+            # 画像の拡張子を取得し、空欄だった場合は.jpgを使用
+            ext = os.path.splitext(img.name)[1] or ".jpg"
+
+            # ユニークの名前をファイル名へ定義
+            filename = f"items/{uuid.uuid4()}{ext}"
+
+            # 「img」というファイルを読み込んで、保存できる形に変え、指定した名前で保存する
+            saved_path = default_storage.save(filename, ContentFile(img.read()))
+
+            # 保存したファイルの「アクセスできるURL」を作って、public_url に入れる
+            public_url = default_storage.url(saved_path)
+
+            # ItemPhotoモデルへ、itemへ紐づく画像のURLを登録する
+            ItemPhoto.objects.create(item=item, url=public_url)
+
+        # アイテムの情報をデータベースの最新状態へ上書きする
+        item.refresh_from_db()
+
+        # 詳細画面へリダイレクト
+        return redirect("item-detail", pk=item.pk)


### PR DESCRIPTION
概要
=========================
アイテム編集機能を実装。画面上へ表示させるため、HTMLも少し変更。

作業内容
=========================
①src/items/forms.py
　アイテム編集フォームを作成。ItemCreateFormと同じフォームを使用したかったが、
　異なる記載方法をしてしまったため、分けて記載している。
　異なる点：クラスベースビューと関数ベースビュー。
　　　　　　ItemCreateFormは、アイテムとclassを分けて実装している。
　　　　　　updateviewにまとめてしまったので、一つのフォームにて作成した。
　　　　　　後日リファクタできそうであれば、対応したいと考えている。
②src/items/templates/items/detail.html
　編集画面への遷移を指定
③src/items/templates/items/edit.html
　編集画面が起動するか確認のため仮作成。
④src/items/urls.py
　ルーティングを設定
⑤src/items/views.py
　編集機能を追加。

ご確認よろしくお願い致します。

