### PR TITLE
アイテム編集画面：画像のエラー表示の修正（バックエンド）

### DIFF
--- a/src/items/views.py
+++ b/src/items/views.py
@@ -211,7 +211,6 @@ class ItemUpdateView(LoginRequiredMixin, UpdateView):
     # Itemモデルへ写真フィールドがなく、かつUI上で画像アップロード欄のみを分離表示しわかりやすくするため。
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["photo_form"] = self.get_form()
         context["photos"] = (
             self.object.itemphoto_set.all()
         )  # ItemPhotoモデルを参照し情報を取得


### PR DESCRIPTION
概要
======================== 
アイテム編集画面にて、画像のエラーが表示されなかったため、対応した。

変更内容
=========================
①src/items/views.py
   photo_formを削除する。
   edit.htmlはちえさん作業中のためプルリクエスト送信いたしません。
　運用の確認は、以下３点のphoto_form→formへ変更し確認いたしました。
<img width="971" height="458" alt="スクリーンショット 2025-08-23 151520" src="https://github.com/user-attachments/assets/39c0fda1-ea48-4478-a712-4f44ebb35326" />
