### PR TITLE
アイテム編集画面のUI修正

### DIFF
--- a/src/items/templates/items/_item_form.html
+++ b/src/items/templates/items/_item_form.html
@@ -1,0 +1,42 @@
+{% load django_bootstrap5 %}
+
+<div class="form-narrow">
+    {% bootstrap_form_errors form type='non_field_errors' %}
+
+    <form method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+
+        {# 基本フィールド（images 以外） #}
+        {% bootstrap_form form exclude='images' %}
+
+        {# 画像アップロード（create/edit 共通） #}
+        {% if form.images %}
+            {% bootstrap_field form.images show_label=True form_group_class="mb-3" %}
+        {% endif %}
+
+        {# 既存画像のデータ置き場（編集時のみ） #}
+        {% if mode == 'edit' and photos %}
+            <div id="existing-photos" class="d-none" aria-hidden="true">
+                {% for photo in photos %}
+                    <div class="existing" data-photo-id="{{ photo.id }}" data-url="{{ photo.url }}"></div>
+                {% endfor %}
+            </div>
+        {% endif %}
+
+        {# プレビュー（新規＋既存すべてここに描画） #}
+        <div id="preview" class="mt-2"></div>
+
+        {# 削除指示の hidden input を詰める場所（JSが生成） #}
+        <div id="delete-bag"></div>
+
+        <div class="action-stack">
+            <button type="submit" class="btn-create">
+                {% if mode == 'edit' %}更新する{% else %}登録する{% endif %}
+            </button>
+        </div>
+    </form>
+
+    <div class="action-stack">
+        <a href="{% url 'item-list' %}" class="btn-back">戻る</a>
+    </div>
+</div>

--- a/src/items/templates/items/create.html
+++ b/src/items/templates/items/create.html
@@ -18,33 +18,6 @@
     <div class="item-header">
         <h1>アイテム新規登録</h1>
     </div>
-
-    <div class="form-narrow">
-        {% if form.non_field_errors %}
-            <div class="alert alert-danger">{{ form.non_field_errors }}</div>
-        {% endif %}
-
-        <form method="post" enctype="multipart/form-data">
-            {% csrf_token %}
-
-            {# メインフォーム（各フィールドのエラーは自動表示） #}
-            {% bootstrap_form form %}
-
-            {# 画像アップロード #}
-            <div id="form-errors" class="alert alert-danger d-none"></div>
-            {% bootstrap_form_errors photo_form type='non_fields' %}
-            {% bootstrap_field photo_form.images show_label=True form_group_class="mb-3" %}
-
-            <div id="preview" class="mt-2"></div>
-
-            <div class="action-stack">
-                <button type="submit" class="btn-create">登録する</button>
-            </div>
-        </form>
-
-        <div class="action-stack">
-          <a href="{% url 'item-list' %}" class="btn-back">戻る</a>
-        </div>
-    </div>
+    {% include "items/_item_form.html" with mode="create" %}
 </div>
 {% endblock %}

--- a/src/items/templates/items/edit.html
+++ b/src/items/templates/items/edit.html
@@ -1,62 +1,34 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load django_bootstrap5 %}
 
 {% block title %}アイテム編集{% endblock %}
 
+{% block extra_css %}
+    {% bootstrap_css %}
+    <link rel="stylesheet" href="{% static 'css/item_form.css' %}">
+{% endblock %}
+
+{% block extra_js %}
+    <script src="{% static 'js/preview.js' %}"></script>
+{% endblock %}
+
 {% block content %}
-    <h1>アイテム編集</h1>
+<div class="item-page items-form-page">
+    <div class="item-header">
+        <h1>アイテム編集</h1>
+    </div>
 
     {% if messages %}
-        <ul>
-            {% for message in messages %}
-                <li style="color:red">{{ message }}</li>
-            {% endfor %}
-        </ul>
+        <div class="alert alert-danger font-regular mb-3" role="alert">
+            <ul class="mb-0">
+                {% for message in messages %}
+                    <li>{{ message }}</li>
+                {% endfor %}
+            </ul>
+        </div>
     {% endif %}
 
-    <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        
-        {# フォーム全体のエラーの表示 #}
-        {{ form.non_field_errors }}
-
-        {# 各フィールドを個別に表示 #}
-        <div class="form-group">
-        {{ form.purchase_date.label}} {{ form.purchase_date }}
-        </div>
-        <div class="form-group">
-        {{ form.price.label }} {{ form.price }}
-        </div>
-        <div class="form-group">
-        {{ form.description.label }} {{ form.description }}
-        </div>
-
-        <div>
-            {{ photo_form.images.label }} {{ photo_form.images }}
-            {% for e in photo_form.images.errors %}
-                <div style="color:red">{{ e }}</div>
-            {% endfor %}
-        </div>
-
-        {# 画像削除#}
-         {% for photo in photos %}
-        <div class="photo-block">
-            <img src="{{ photo.url }}" alt="登録済み画像" width="150" height="150">
-
-            <label>
-            <input type="checkbox" name="delete_photos" value="{{ photo.id }}">
-            削除
-            </label>
-        </div>
-        {% endfor %} 
-
-        <div id="preview" style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px;"></div>
-
-        <button type="submit">登録する</button>
-    </form>
-    <a href="{% url 'item-list' %}" class="btn btn-primary">戻る</a>
-
-    {% block extra_js %}
-        <script src="{% static 'js/preview.js' %}"></script>
-    {% endblock %}    
+    {% include "items/_item_form.html" with mode="edit" photos=photos %}
+</div>   
 {% endblock %}

--- a/src/static/css/item_form.css
+++ b/src/static/css/item_form.css
@@ -9,6 +9,7 @@
   font-family: "M PLUS Rounded 1c", sans-serif;
   font-weight: 400;
   font-style: normal;
+  overflow-x: hidden; /* 画面横はみ出し防止 */
 }
 
 /* フォーム幅を少し狭く＆中央寄せ */
@@ -31,9 +32,8 @@
   border: 1px solid transparent;
   text-decoration: none;
   cursor: pointer;
-  transition: background-color 0.2s, border-color 0.2s, color 0.2s,
-    transform 0.02s;
-  width: 8rem; /* 同じ横幅に */
+  transition: background-color 0.2s, border-color 0.2s, color 0.2s, transform 0.02s;
+  width: 8rem; /* 同じ横幅に（長文で崩れるなら min-width に変更） */
 }
 
 /* 登録ボタン */
@@ -41,7 +41,6 @@
   background-color: #d9a299;
   color: #fff;
   border-color: #d9a299;
-  margin-top: 2rem; /* 必要なければ削除して .action-stack で調整 */
 }
 .items-form-page .btn-create:hover,
 .items-form-page .btn-create:focus {
@@ -52,8 +51,8 @@
 /* 戻るボタン */
 .items-form-page .btn-back {
   background-color: #f5f5f5;
-  color: #946c66;
-  border: 1px solid #946c66;
+  color: var(--brand-prim);
+  border: 1px solid var(--brand-prim);
 }
 .items-form-page .btn-back:hover,
 .items-form-page .btn-back:focus {
@@ -67,38 +66,44 @@
 }
 .items-form-page .btn-create:focus-visible,
 .items-form-page .btn-back:focus-visible {
-  outline: 2px solid #946c66;
+  outline: 2px solid var(--brand-prim);
   outline-offset: 2px;
 }
 
-/* 縦積み＆中央寄せ */
+/* 縦積み＆中央寄せ（送信ボタン行・戻る行） */
 .items-form-page .action-stack {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-  margin-top: 8px;
+  justify-content: center;   /* 横中央 */
+  align-items: center;       /* 高さのばらつき吸収 */
+  gap: 12px;
+  margin-top: 16px;
+  flex-wrap: wrap;           /* 狭い画面で折り返し */
+  flex-direction: row;       /* ボタンが縦積み希望なら column に */
 }
 
-/* プレビュー（スマホは2列） */
+/* プレビュー（スマホは2列→広い画面で4列） */
 .items-form-page #preview {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
   margin-top: 8px;
 }
+@media (min-width: 640px) {
+  .items-form-page #preview {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
 
-/* 画像枠（角丸とオーバーレイ用） */
+/* 画像カード */
 .items-form-page #preview .preview-item {
   position: relative;
   border-radius: 8px;
   overflow: hidden; /* ×ボタンを内側に収める */
+  box-shadow: 0 2px 8px rgba(0,0,0,.06);
 }
-
-/* サムネ（正方形トリミング） */
 .items-form-page #preview .preview-img {
   width: 100%;
-  aspect-ratio: 1/1;
+  aspect-ratio: 1 / 1;   /* 正方形 */
   object-fit: cover;
   display: block;
 }
@@ -106,24 +111,25 @@
 /* ×ボタン */
 .items-form-page #preview .preview-remove {
   position: absolute;
-  top: 4px;
-  right: 4px;
-  width: 24px;
-  height: 24px;
+  top: 6px;
+  right: 6px;
+  width: 28px;
+  height: 28px;
   border: none;
   border-radius: 9999px;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0,0,0,.6);
   color: #fff;
   line-height: 1;
+  font-size: 18px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
 }
 .items-form-page #preview .preview-remove:hover {
-  background: rgba(0, 0, 0, 0.75);
+  background: rgba(0,0,0,.75);
 }
 .items-form-page #preview .preview-remove:focus-visible {
-  outline: 2px solid #946c66;
+  outline: 2px solid var(--brand-prim);
   outline-offset: 2px;
 }

--- a/src/static/js/preview.js
+++ b/src/static/js/preview.js
@@ -1,25 +1,58 @@
 // プレビュー画像（削除対応）
+// 既存画像（編集時）と新規選択画像を同じプレビューにまとめ、×で個別に除外できる。
+// 既存画像を×で消した場合はhidden input(name="delete_photos") を追加してサーバへ送る。
+// 新規画像を×で消した場合はinput.filesからも取り除いて送信対象から外す。
 document.addEventListener("DOMContentLoaded", function () {
   // id があれば優先。無ければ name="images" を拾う
   const input =
     document.getElementById("images-input") ||
     document.querySelector('input[type="file"][name="images"]');
+
   const preview = document.getElementById("preview");
-  if (!input || !preview) return;
+  const deleteBag = document.getElementById("delete-bag"); // hidden input を詰める場所
+  const existingNodes = Array.from(
+    document.querySelectorAll("#existing-photos .existing")
+  );
+
+  // 画面に必要な要素がない場合は何もしない
+  if (!preview) return;
 
   // 選択中のファイル状態を保持（File と表示用URL・識別子）
-  let filesState = []; // [{ file, url, id }]
+  // 新規: { kind:'new', file, url, id } / 既存: { kind:'existing', id, url }
+  let filesState = [];      // 新規選択ファイル
+  let existingState = existingNodes.map((n) => ({
+    kind: "existing",
+    id: Number(n.dataset.photoId),
+    url: n.dataset.url,
+  }));
   let counter = 0;
 
   function rebuildInputFiles() {
+    if (!input) return;
     const dt = new DataTransfer();
     filesState.forEach(({ file }) => dt.items.add(file));
     input.files = dt.files; // ← 送信される中身を更新
   }
 
+  function addDeleteHidden(id) {
+    if (!deleteBag) return;
+    const hidden = document.createElement("input");
+    hidden.type = "hidden";
+    hidden.name = "delete_photos";
+    hidden.value = String(id);
+    deleteBag.appendChild(hidden);
+  }
+
   function render() {
     preview.innerHTML = "";
-    filesState.forEach(({ url, id }) => {
+
+    // 表示は「既存 → 新規」の順
+    const all = [
+      ...existingState, // {kind:'existing', id, url}
+      ...filesState.map((f) => ({ kind: "new", id: f.id, url: f.url })),
+    ];
+
+    all.forEach(({ kind, id, url }) => {
       const item = document.createElement("div");
       item.className = "preview-item";
 
@@ -36,13 +69,21 @@ document.addEventListener("DOMContentLoaded", function () {
       btn.innerHTML = "&times;"; // ×
 
       btn.addEventListener("click", () => {
-        const idx = filesState.findIndex((f) => f.id === id);
-        if (idx > -1) {
-          URL.revokeObjectURL(filesState[idx].url);
-          filesState.splice(idx, 1); // 状態から削除
-          rebuildInputFiles();       // input.files を更新
-          render();                  // 画面を再描画
+        if (kind === "existing") {
+          // 既存: 状態から削除し、hidden を追加
+          const i = existingState.findIndex((e) => e.id === id);
+          if (i > -1) existingState.splice(i, 1);
+          addDeleteHidden(id);
+        } else {
+          // 新規: File を除外して input.files を更新
+          const i = filesState.findIndex((f) => f.id === id);
+          if (i > -1) {
+            URL.revokeObjectURL(filesState[i].url);
+            filesState.splice(i, 1); // 状態から削除
+            rebuildInputFiles();     // input.files を更新
+          }
         }
+        render(); // 画面を再描画
       });
 
       item.appendChild(img);
@@ -51,23 +92,36 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
-  input.addEventListener("change", () => {
-    // 今回新たに選ばれた分だけを追加（重複はスキップ）
-    Array.from(input.files).forEach((file) => {
-      const exists = filesState.some(
-        ({ file: f }) =>
-          f.name === file.name && f.size === file.size && f.lastModified === file.lastModified
-      );
-      if (!exists) {
-        filesState.push({ file, url: URL.createObjectURL(file), id: ++counter });
-      }
+  // 新規選択時の処理
+  if (input) {
+    input.addEventListener("change", () => {
+      // 今回新たに選ばれた分だけを追加（重複はスキップ）
+      Array.from(input.files).forEach((file) => {
+        const exists = filesState.some(
+          ({ file: f }) =>
+            f.name === file.name &&
+            f.size === file.size &&
+            f.lastModified === file.lastModified
+        );
+        if (!exists) {
+          filesState.push({
+            kind: "new",
+            file,
+            url: URL.createObjectURL(file),
+            id: ++counter,
+          });
+        }
+      });
+      rebuildInputFiles();
+      render();
     });
-    rebuildInputFiles();
-    render();
-  });
 
-  // 履歴戻る等で既にファイルが入っている場合のフォールバック
-  if (input.files && input.files.length) {
-    input.dispatchEvent(new Event("change"));
+    // 履歴戻る等で既にファイルが入っている場合のフォールバック
+    if (input.files && input.files.length) {
+      input.dispatchEvent(new Event("change"));
+    }
   }
+
+  // 初期描画（既存のみでも描画）
+  render();
 });


### PR DESCRIPTION
### 対応内容
- アイテム編集画面のUI
  - form部分をアイテム登録画面と共通テンプレートにした
  - photo_formを辞めてformで対応するようにしたことに伴って
    - 画像アップロードフォームはItemCreateFormに入れて（ItemUpdateFormには既にあった）、PhotoUploadFormは削除
    - フォーム項目のエラーと画像のエラーを同時に出せるように、画像のエラーチェックをforms.pyのclean()に移植し、views.pyのform_valid()からは削除
  - 説明・メモだけは未登録状態が有り得るので、編集画面でもプレースホルダーを表示するように修正
  - 画像の削除はプレビュー表示と合わせ、×アイコンで削除して、「更新する」押下時にプレビューにある画像で更新するように修正

### 動作video
https://www.loom.com/share/3ac9045b44cb42c1987f5d7f5f4a59af