### PR TITLE
動確後のCSS修正漏れの対応

### DIFF
--- a/src/items/forms.py
+++ b/src/items/forms.py
@@ -188,6 +188,7 @@ class ItemUpdateForm(forms.ModelForm):
                 attrs={
                     "class": "form-control",  # CSSにて使用するクラス
                     # "placeholder": "2025-01-01",
+                    "type": "date",  # カレンダー形式の選択
                 }
             ),
             "price": forms.NumberInput(

--- a/src/items/templates/items/detail.html
+++ b/src/items/templates/items/detail.html
@@ -28,7 +28,7 @@
         {% endfor %}
     </div>
     <div class="detail-btn-container">
-        <a href="{% url 'item-edit' item.pk %}" class="detail-btn-action btn-edit">編集する</a>
+        <a href="{% url 'item-edit' item.pk %}" class="detail-btn-action btn-edit font-regular">編集する</a>
         <a href="{% url 'item-list' %}" class="detail-btn-action btn-back font-regular">戻る</a>
     </div>
 </div>

--- a/src/static/css/base_auth.css
+++ b/src/static/css/base_auth.css
@@ -4,9 +4,9 @@ html {
 
 body {
     font-family: Arial, sans-serif;
-    /* background-color: #FDF6F1; */
     background-color: #F0E4D3;
     text-align: center;
+    overflow-y: auto;
 }
 
 header {

--- a/src/static/css/item_form.css
+++ b/src/static/css/item_form.css
@@ -133,3 +133,21 @@
   outline: 2px solid var(--brand-prim);
   outline-offset: 2px;
 }
+
+/* ネイティブUIを生かし、左寄せに統一 */
+input[type="date"] {
+  appearance: auto;
+  -webkit-appearance: auto; /* iOS */
+  text-align: left;
+}
+
+/* iOS Safari の内部編集領域も左寄せ */
+input[type="date"]::-webkit-datetime-edit,
+input[type="date"]::-webkit-date-and-time-value {
+  text-align: left;
+}
+
+/* 念のため、中央寄せ化している既存指定を打ち消す */
+.form-control[type="date"] {
+  text-align: left !important;
+}

--- a/src/templates/base_auth.html
+++ b/src/templates/base_auth.html
@@ -17,7 +17,7 @@
 
     {% block extra_css %}{% endblock %}
 </head>
-<body >
+<body class="d-flex flex-column min-vh-100">
     {% if messages %}
     <div class="container mt-3">
         {% for message in messages %}
@@ -28,21 +28,19 @@
     </div>
     {% endif %}
 
-    <div class="d-flex justify-content-center align-items-center" style="height: 100vh;">
-        <div class="text-white p-3">
-            <header>
-                <h1><img src="{% static 'img/main_logo_white.png' %}" alt="ロゴ"></h1>
-            </header>
-
-            <main>
-                {% block content %}{% endblock %}
-            </main>
-
-            <footer class="fixed-bottom text-black text-center font-regular">
-                <p>&copy; 2025 Summer C team</p>
-            </footer>
+    <header class="text-center">
+        <h1><img src="{% static 'img/main_logo_white.png' %}" alt="ロゴ"></h1>
+    </header>
+    
+    <main class="flex-grow-1 d-flex justify-content-center">
+        <div class="text-white p-3" style="width:100%;max-width:520px;">
+            {% block content %}{% endblock %}
         </div>
-    </div>
+    </main>
+
+    <footer class="text-black text-center font-regular mt-auto">
+        <p>&copy; 2025 Summer C team</p>
+    </footer>
 
     {# ページ固有のJSを差し込みたい場合 #}
     {% bootstrap_javascript %}

--- a/src/templates/registration/login.html
+++ b/src/templates/registration/login.html
@@ -14,7 +14,6 @@
 
     <form method="post">
         {% csrf_token %}
-        {% comment %} {{ form.as_p }} {% endcomment %}
         {% bootstrap_form form %}
 
         <div class="container mt-5">
@@ -23,7 +22,8 @@
     </form>
 
     <p class="to-login font-regular">
-        アカウントをお持ちでない方は、<a href="{% url 'signup' %}">新規登録</a>へ
+        アカウントをお持ちでない方は、<br>
+        <a href="{% url 'signup' %}">新規登録</a>へ
     </p>
 </div>
 {% endblock %}

--- a/src/templates/registration/signup.html
+++ b/src/templates/registration/signup.html
@@ -21,12 +21,13 @@
     </form>
 
     <p class="to-signup font-regular">
-        アカウントをお持ちの方は、<a href="{% url 'login' %}">ログイン画面</a>へ
+        アカウントをお持ちの方は、<br>
+        <a href="{% url 'login' %}">ログイン画面</a>へ
     </p>
 </div>
 {% endblock %}
 
 {% block extra_js %}
     <script src="{% static 'js/password_eye.js' %}"></script>
-{% endblock %}    
+{% endblock %}
 


### PR DESCRIPTION
### 対応内容
以下の事象を修正しました。
- ユーザー新規登録画面：ログインへの遷移メッセージとフッターが被っている
- アイテム詳細画面：「編集する」ボタンのフォント
- アイテム編集画面：購入日がカレンダー入力になっていない
- アイテム登録画面：購入日の入力ヒントが表示されない。値を入力すると中央寄せになる（本番環境のみなので、開発で確認できない。一旦効きそうなCSSを入れてみました）