### PR TITLE
アイテムフォーム（登録＆編集）のplaceholderを変更

### DIFF
--- a/src/items/forms.py
+++ b/src/items/forms.py
@@ -140,7 +140,7 @@ class ItemCreateForm(forms.ModelForm):
                 attrs={
                     "class": "form-control",  # CSSにて使用するクラス
                     "rows": 4,  # 初期表示で4行文の高さに設定
-                    "placeholder": "例：〇〇(店名,場所）にて購入",
+                    "placeholder": "例：二子玉川で購入。かわいい！！",
                 }
             ),
         }
@@ -194,7 +194,7 @@ class ItemUpdateForm(forms.ModelForm):
             "price": forms.NumberInput(
                 attrs={
                     "class": "form-control",  # CSSにて使用するクラス
-                    # "placeholder": "2000",
+                    "placeholder": "2000",
                     "min": "0",  # マイナスの価格入力がブラウザ上で禁止される
                 }
             ),


### PR DESCRIPTION
概要
=============================
アイテムフォーム（登録&編集）のplaceholderを一致させるため、変更


変更内容
============================= 
src/items/forms.py
記載が一致するよう表記
<img width="300" height="654" alt="image" src="https://github.com/user-attachments/assets/243f05d3-57ad-4404-8468-2a26711d60c9" />
<img width="302" height="630" alt="image" src="https://github.com/user-attachments/assets/5725e85a-9bdf-443e-8e6e-833e7c266bd2" />
