### PR TITLE
購入日入力フォームの修正

### DIFF
--- a/src/items/forms.py
+++ b/src/items/forms.py
@@ -98,6 +98,23 @@ class LoginForm(forms.Form):
 
 # アイテム新規登録
 class ItemCreateForm(forms.ModelForm):
+    # スマホの表示を合わせるため、type="text"+flatpickr化
+    purchase_date = forms.DateField(
+        label="購入日",
+        required=True,
+        input_formats=["%Y-%m-%d"],
+        widget=forms.DateInput(
+            format="%Y-%m-%d",
+            attrs={
+                "class": "form-control datepicker",
+                "type": "text",
+                "autocomplete": "off",
+                "placeholder": "YYYY-MM-DD",
+            }
+        ),
+        error_messages={"invalid": "日付は YYYY-MM-DD 形式で入力してください。"},
+    )
+
     # createでも同じUIを使えるように追加
     # 画像をアップロードするためのフォーム（Itemモデルにフィールドなくても問題なし）
     images = forms.FileField(
@@ -123,12 +140,6 @@ class ItemCreateForm(forms.ModelForm):
 
         # 入力欄のカスタマイズ
         widgets = {
-            "purchase_date": forms.DateInput(
-                attrs={
-                    "class": "form-control",  # CSSにて使用するクラス
-                    "type": "date",  # カレンダー形式の選択
-                }
-            ),
             "price": forms.NumberInput(
                 attrs={
                     "class": "form-control",  # CSSにて使用するクラス
@@ -148,6 +159,22 @@ class ItemCreateForm(forms.ModelForm):
 
 # アイテム編集フォーム
 class ItemUpdateForm(forms.ModelForm):
+    # スマホの表示を合わせるため、type="text"+flatpickr化
+    purchase_date = forms.DateField(
+        label="購入日",
+        required=True,
+        input_formats=["%Y-%m-%d"],
+        widget=forms.DateInput(
+            format="%Y-%m-%d",
+            attrs={
+                "class": "form-control datepicker",
+                "type": "text",
+                "autocomplete": "off",
+                "placeholder": "YYYY-MM-DD",
+            }
+        ),
+        error_messages={"invalid": "日付は YYYY-MM-DD 形式で入力してください。"},
+    )
     # 画像をアップロードするためのフォーム（Itemモデルにフィールドなくても問題なし）
     images = forms.FileField(
         widget=forms.ClearableFileInput(
@@ -184,13 +211,6 @@ class ItemUpdateForm(forms.ModelForm):
         # 入力欄のカスタマイズ
         #  Updateのため、未入力が有り得るdescriptionのみplaceholder表示
         widgets = {
-            "purchase_date": forms.DateInput(
-                attrs={
-                    "class": "form-control",  # CSSにて使用するクラス
-                    # "placeholder": "2025-01-01",
-                    "type": "date",  # カレンダー形式の選択
-                }
-            ),
             "price": forms.NumberInput(
                 attrs={
                     "class": "form-control",  # CSSにて使用するクラス

--- a/src/items/templates/items/create.html
+++ b/src/items/templates/items/create.html
@@ -10,12 +10,13 @@
 {% endblock %}
 
 {% block extra_js %}
+    <script src="{% static 'js/datepicker.js' %}"></script>
     <script src="{% static 'js/preview.js' %}"></script>
 {% endblock %}
 
 {% block content %}
 <div class="item-page items-form-page">
-    <div class="item-header">
+    <div class="item-border-header">
         <h1>アイテム新規登録</h1>
     </div>
     {% include "items/_item_form.html" with mode="create" %}

--- a/src/items/templates/items/edit.html
+++ b/src/items/templates/items/edit.html
@@ -10,12 +10,13 @@
 {% endblock %}
 
 {% block extra_js %}
+    <script src="{% static 'js/datepicker.js' %}"></script>
     <script src="{% static 'js/preview.js' %}"></script>
 {% endblock %}
 
 {% block content %}
 <div class="item-page items-form-page">
-    <div class="item-header">
+    <div class="item-border-header">
         <h1>アイテム編集</h1>
     </div>
 

--- a/src/static/css/item_form.css
+++ b/src/static/css/item_form.css
@@ -134,20 +134,13 @@
   outline-offset: 2px;
 }
 
-/* ネイティブUIを生かし、左寄せに統一 */
-input[type="date"] {
-  appearance: auto;
-  -webkit-appearance: auto; /* iOS */
-  text-align: left;
-}
+/* flexの子要素はみ出し対策（Bootstrap .row 直下に効かせる） */
+.row > * { min-width: 0; }
 
-/* iOS Safari の内部編集領域も左寄せ */
-input[type="date"]::-webkit-datetime-edit,
-input[type="date"]::-webkit-date-and-time-value {
-  text-align: left;
-}
-
-/* 念のため、中央寄せ化している既存指定を打ち消す */
-.form-control[type="date"] {
-  text-align: left !important;
+/* 入力幅とiOSのズーム抑止 */
+input.form-control.datepicker {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  font-size: 16px; /* iOSのフォーカス自動ズーム回避 */
 }

--- a/src/static/js/datepicker.js
+++ b/src/static/js/datepicker.js
@@ -1,0 +1,10 @@
+document.addEventListener("DOMContentLoaded", function () {
+    flatpickr(".datepicker", {
+    dateFormat: "Y-m-d",
+    allowInput: true,
+    locale: "ja",
+    disableMobile: true,
+    // minDate: "2000-01-01",
+    maxDate: "today",
+    });
+});

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -11,6 +11,10 @@
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500&display=swap" rel="stylesheet">
     {% block extra_css %}{% endblock %}
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
+    <!-- flatpickr -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/ja.js"></script>
 </head>
 <body>
     <div class="wrapper">


### PR DESCRIPTION
### 対応内容
- アイテム登録画面、アイテム編集画面の、購入日フォームがスマホ表示で崩れていたことの修正
  - datepickerをjsで実装する形に修正
  - プレースホルダーはYYYY-MM-DDに変更
  - 未来日は登録できない制御

- アイテム登録画面、アイテム編集画面が、スクロールすると購入日がヘッダーの下にあることが分かりづらかったため、ヘッダーにボーダーを追加