### PR TITLE
絵文字対応の追加

### DIFF
--- a/src/closet_search/settings/dev.py
+++ b/src/closet_search/settings/dev.py
@@ -13,6 +13,10 @@ DATABASES = {
         "PASSWORD": os.getenv("DB_PASSWORD", "app_pass"),
         "HOST": os.getenv("DB_HOST", "db"),
         "PORT": os.getenv("DB_PORT", "3306"),
+        "OPTIONS": {
+            "charset": "utf8mb4",
+            "init_command": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'",
+        },
     }
 }
 

--- a/src/closet_search/settings/prod.py
+++ b/src/closet_search/settings/prod.py
@@ -16,9 +16,9 @@ DATABASES = {
         "HOST": os.environ["DB_HOST"],
         "PORT": os.getenv("DB_PORT", "3306"),
         "OPTIONS": {
-             "charset": "utf8mb4",
-             "init_command": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'",
-         },
+            "charset": "utf8mb4",
+            "init_command": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'",
+        },
     },
     "replica": {
         "ENGINE": "django.db.backends.mysql",
@@ -28,9 +28,9 @@ DATABASES = {
         "HOST": os.environ["DB_HOST_REPLICA"],
         "PORT": os.getenv("DB_PORT", "3306"),
         "OPTIONS": {
-             "charset": "utf8mb4",
-             "init_command": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'",
-         },
+            "charset": "utf8mb4",
+            "init_command": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'",
+        },
     },
 }
 DATABASE_ROUTERS = ["closet_search.db_routers.PrimaryReplicaRouter"]

--- a/src/closet_search/settings/prod.py
+++ b/src/closet_search/settings/prod.py
@@ -15,6 +15,10 @@ DATABASES = {
         "PASSWORD": os.environ["DB_PASSWORD"],
         "HOST": os.environ["DB_HOST"],
         "PORT": os.getenv("DB_PORT", "3306"),
+        "OPTIONS": {
+             "charset": "utf8mb4",
+             "init_command": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'",
+         },
     },
     "replica": {
         "ENGINE": "django.db.backends.mysql",
@@ -23,6 +27,10 @@ DATABASES = {
         "PASSWORD": os.environ["DB_PASSWORD"],
         "HOST": os.environ["DB_HOST_REPLICA"],
         "PORT": os.getenv("DB_PORT", "3306"),
+        "OPTIONS": {
+             "charset": "utf8mb4",
+             "init_command": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci'",
+         },
     },
 }
 DATABASE_ROUTERS = ["closet_search.db_routers.PrimaryReplicaRouter"]


### PR DESCRIPTION
### 対応内容
絵文字が見れるように対応。
DB側はutf8mb4対応できていたので、Django の DB 接続を utf8mb4 に固定