### PR TITLE
編集画面の戻るボタンの遷移先を修正

### DIFF
--- a/src/items/templates/items/_item_form.html
+++ b/src/items/templates/items/_item_form.html
@@ -60,6 +60,10 @@
     </form>
 
     <div class="action-stack">
-        <a href="{% url 'item-list' %}" class="btn-back">戻る</a>
+        {% if mode == 'edit' %}
+            <a href="{% url 'item-detail' object.pk %}" class="btn-back">戻る</a>
+        {% else %}
+            <a href="{% url 'item-list' %}" class="btn-back">戻る</a>
+        {% endif %}
     </div>
 </div>


### PR DESCRIPTION
### 対応内容
フォームを共通化した際に、戻るボタンの考慮が漏れていました。
登録画面→一覧へ
編集画面→詳細へ
となるように修正しました。